### PR TITLE
fix: update recent activity workflow to use correct action

### DIFF
--- a/.github/workflows/update-activity.yml
+++ b/.github/workflows/update-activity.yml
@@ -2,7 +2,7 @@ name: Update README with Recent Activity
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 */6 * * *" # Every 6 hours
   workflow_dispatch:
 
 jobs:
@@ -15,12 +15,8 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Update recent activity
-        uses: gautamkrishnar/blog-post-workflow@v1
+        uses: jamesgeorge007/github-activity-readme@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          feed_list: https://github.com/Ven0m0.atom
-          max_post_count: 3
-          readme_path: ./README.md
-          comment_tag_name: activity
-          commit_message: "chore(readme): update recent activity"
-          template: "- [$title]($url)$newline"
-          date_format: d/m/yy
+          MAX_LINES: 5


### PR DESCRIPTION
- Replace blog-post-workflow with github-activity-readme action
- Change schedule to run every 6 hours instead of daily
- Use GITHUB_TOKEN for authentication
- Set MAX_LINES to 5 for better visibility