### PR TITLE
fix: sanitize repository description and name in profile activity workflow

### DIFF
--- a/.github/workflows/profile-activity.yml
+++ b/.github/workflows/profile-activity.yml
@@ -51,13 +51,24 @@ jobs:
               per_page: 100,
             });
 
+            function escapeHtml(unsafe) {
+              return unsafe
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+            }
+
             const latest = repos
               .filter(repo => !repo.archived && !repo.disabled && !repo.fork && repo.name !== '.github')
               .slice(0, 5)
               .map(repo => {
-                const desc = repo.description ? repo.description.trim() : 'No description yet';
+                const descRaw = repo.description ? repo.description.trim() : 'No description yet';
+                const desc = escapeHtml(descRaw);
+                const name = escapeHtml(repo.name);
                 const date = new Date(repo.pushed_at).toISOString().split('T')[0];
-                return `- [${repo.name}](${repo.html_url}) — ${desc} <sub>${date}</sub>`;
+                return `- [${name}](${repo.html_url}) — ${desc} <sub>${date}</sub>`;
               });
 
             core.info(`Found ${latest.length} repos to display`);


### PR DESCRIPTION
This change addresses a security vulnerability where repository descriptions and names were interpolated directly into the README without sanitization. This could allow for HTML injection or layout breakage if a repository description contained malicious content.

The fix introduces an `escapeHtml` helper function within the `github-script` block and applies it to both the repository description and name before interpolation. This ensures that special characters like `<`, `>`, `&`, `"`, and `'` are properly escaped.

---
*PR created automatically by Jules for task [15090796285214248070](https://jules.google.com/task/15090796285214248070) started by @Ven0m0*