### PR TITLE
🔒 Security: Harden GitHub URL regex

### DIFF
--- a/scripts/update_profile_activity.py
+++ b/scripts/update_profile_activity.py
@@ -24,7 +24,7 @@ STATUS_MAP = {
     "archived": {"emoji": "📥", "label": "Archived"},
 }
 
-GITHUB_RE = re.compile(r"https://github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+)")
+GITHUB_RE = re.compile(r"https://github\.com/(?P<owner>[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)/(?P<repo>(?=.*[a-zA-Z0-9])[\w.-]+)")
 LINE_RE = re.compile(
     r"^(?P<prefix>\s*-\s*)(?:(?P<emoji>\S+)\s+)?\*\*(?P<label>[^*]+?)\*\*(?P<ws>\s*)(?P<rest>.+)$",
 )


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in `scripts/update_profile_activity.py` where a loose regex allowed potentially malicious characters (like `.` and `..`) in GitHub usernames and repository names.

⚠️ **Risk:** The previous regex could be exploited for path traversal or API manipulation if an attacker could inject malicious URLs into the README or other inputs processed by the script.

🛡️ **Solution:** Updated the regex `GITHUB_RE` to strictly enforce GitHub's naming conventions:
- **Owner:** Must be alphanumeric, can contain single hyphens, no leading/trailing hyphens/dots.
- **Repo:** Must contain at least one alphanumeric character (prevents `..`), allowing standard alphanumeric, dots, hyphens, and underscores.

---
*PR created automatically by Jules for task [3449693558033095040](https://jules.google.com/task/3449693558033095040) started by @Ven0m0*