### PR TITLE
Refactor: Unify API retry logic in `Queries` class

### DIFF
--- a/scripts/generate_stats_images.py
+++ b/scripts/generate_stats_images.py
@@ -15,6 +15,7 @@ import sys
 import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, Awaitable, Callable
 
 import aiohttp
 
@@ -32,38 +33,88 @@ class Queries:
     def __post_init__(self) -> None:
         self.semaphore = asyncio.Semaphore(self.max_concurrent)
 
+    async def _request_with_retry(
+        self,
+        method: str,
+        url: str,
+        retries: int,
+        backoff_cap: float = 8.0,
+        validate_func: (
+            Callable[[aiohttp.ClientResponse, int], Awaitable[tuple[bool, Any]]] | None
+        ) = None,
+        **kwargs,
+    ) -> Any:
+        """Execute a request with retry logic.
+
+        Args:
+            method: HTTP method (GET, POST, etc.)
+            url: Request URL
+            retries: Maximum number of retries
+            backoff_cap: Maximum sleep duration in seconds
+            validate_func: Async callback that takes (response, attempt_index)
+                           and returns (should_retry, result).
+                           If should_retry is False, result is returned.
+                           If should_retry is True, loop continues.
+                           Can raise exceptions to abort retries.
+            **kwargs: Arguments passed to session.request
+        """
+        for attempt in range(retries):
+            should_retry = False
+            sleep_duration = 0.0
+            async with self.semaphore:
+                try:
+                    async with self.session.request(
+                        method,
+                        url,
+                        timeout=aiohttp.ClientTimeout(total=30),
+                        **kwargs,
+                    ) as r:
+                        if validate_func:
+                            should_retry, result = await validate_func(r, attempt)
+                            if not should_retry:
+                                return result
+                            # Standard backoff for retryable responses
+                            sleep_duration = min(2 ** min(attempt, 3), backoff_cap)
+                        else:
+                            r.raise_for_status()
+                            return await r.json()
+                except aiohttp.ClientError as e:
+                    if attempt == retries - 1:
+                        raise RuntimeError(
+                            f"Request failed for {url} after {retries} attempts: {e}"
+                        )
+                    should_retry = True
+                    sleep_duration = min(2 ** min(attempt, 3), backoff_cap)
+
+            if should_retry:
+                await asyncio.sleep(sleep_duration)
+        return {}
+
     async def query(self, generated_query: str, retries: int = 3) -> dict:
         """Execute a GraphQL query against GitHub API."""
         headers = {"Authorization": f"Bearer {self.access_token}"}
-        for attempt in range(retries):
-            async with self.semaphore:
-                try:
-                    r = await self.session.post(
-                        "https://api.github.com/graphql",
-                        headers=headers,
-                        json={"query": generated_query},
-                        timeout=aiohttp.ClientTimeout(total=30),
-                    )
-                    r.raise_for_status()
-                    result = await r.json()
-                    if "errors" in result:
-                        errors = result.get("errors", [])
-                        error_msg = "; ".join(
-                            e.get("message", "Unknown error") for e in errors
-                        )
-                        print(f"GraphQL query returned errors: {error_msg}")
-                        if attempt == retries - 1:
-                            raise RuntimeError(f"GraphQL API errors: {error_msg}")
-                        continue
-                    return result
-                except aiohttp.ClientError as e:
-                    if attempt == retries - 1:
-                        msg = f"GraphQL query failed after {retries} attempts: {e}"
-                        raise RuntimeError(msg)
-                    print(f"GraphQL attempt {attempt + 1}/{retries} failed: {e}")
-            if attempt < retries - 1:
-                await asyncio.sleep(2**attempt)
-        return {}
+
+        async def validate(r: aiohttp.ClientResponse, attempt: int) -> tuple[bool, Any]:
+            r.raise_for_status()
+            result = await r.json()
+            if "errors" in result:
+                errors = result.get("errors", [])
+                error_msg = "; ".join(e.get("message", "Unknown error") for e in errors)
+                print(f"GraphQL query returned errors: {error_msg}")
+                if attempt == retries - 1:
+                    raise RuntimeError(f"GraphQL API errors: {error_msg}")
+                return True, None
+            return False, result
+
+        result = await self._request_with_retry(
+            "POST",
+            "https://api.github.com/graphql",
+            retries=retries,
+            headers=headers,
+            json={"query": generated_query},
+            validate_func=validate,
+        )
+        return result
 
     async def query_rest(
         self,
@@ -75,55 +126,41 @@ class Queries:
         headers = {"Authorization": f"Bearer {self.access_token}"}
         params = params or {}
         path = path.lstrip("/")
-        for attempt in range(max_attempts):
-            should_retry = False
-            sleep_duration = 0
-            async with self.semaphore:
-                try:
-                    r = await self.session.get(
-                        f"https://api.github.com/{path}",
-                        headers=headers,
-                        params=tuple(params.items()),
-                        timeout=aiohttp.ClientTimeout(total=30),
-                    )
-                    if r.status == 200:
-                        return await r.json()
-                    if r.status == 404:
-                        return {}
-                    if r.status in (401, 403):
-                        error_body = await r.text()
-                        msg = (
-                            f"Authentication failed for {path} "
-                            f"(status {r.status}): {error_body}"
-                        )
-                        raise RuntimeError(msg)
-                    if r.status == 202:
-                        should_retry = True
-                        sleep_duration = min(2 ** min(attempt // 10, 3), 8)
-                    elif attempt < max_attempts - 1:
-                        should_retry = True
-                        sleep_duration = min(2 ** min(attempt // 5, 3), 8)
-                    else:
-                        error_body = await r.text()
-                        msg = (
-                            f"REST API request failed for {path} "
-                            f"with status {r.status}: {error_body}"
-                        )
-                        raise RuntimeError(msg)
-                except aiohttp.ClientError as e:
-                    if attempt == max_attempts - 1:
-                        msg = (
-                            f"REST query failed for {path} "
-                            f"after {max_attempts} attempts: {e}"
-                        )
-                        raise RuntimeError(msg)
-                    should_retry = True
-                    sleep_duration = min(2 ** min(attempt // 5, 3), 8)
-            if should_retry:
-                await asyncio.sleep(sleep_duration)
-            else:
-                return {}
-        return {}
+
+        async def validate(r: aiohttp.ClientResponse, attempt: int) -> tuple[bool, Any]:
+            if r.status == 200:
+                return False, await r.json()
+            if r.status == 404:
+                return False, {}
+            if r.status in (401, 403):
+                error_body = await r.text()
+                msg = (
+                    f"Authentication failed for {path} "
+                    f"(status {r.status}): {error_body}"
+                )
+                raise RuntimeError(msg)
+            if r.status == 202:
+                # 202 Accepted (processing)
+                return True, None
+
+            # Other errors
+            if attempt == max_attempts - 1:
+                error_body = await r.text()
+                msg = (
+                    f"REST API request failed for {path} "
+                    f"with status {r.status}: {error_body}"
+                )
+                raise RuntimeError(msg)
+            return True, None
+
+        return await self._request_with_retry(
+            "GET",
+            f"https://api.github.com/{path}",
+            retries=max_attempts,
+            headers=headers,
+            params=params,
+            validate_func=validate,
+        )
 
     @staticmethod
     def repos_overview(


### PR DESCRIPTION
This PR addresses a code health issue in `scripts/generate_stats_images.py`.

**Changes:**
- Extracted duplicate retry loop logic into a new `_request_with_retry` method.
- Unified backoff strategy to standard capped exponential backoff (`min(2**attempt, 8)`).
- Fixed a bug in GraphQL queries where retries happened immediately without sleep on API errors.
- Improved error handling consistency between GraphQL and REST clients.
- Added type hints and docstrings.

**Verification:**
- Verified using reproduction scripts (since no dedicated test suite exists) covering:
    - GraphQL success and retry on error.
    - REST success, 404, 202 retry, and auth failure.
- Confirmed correct backoff behavior (sleeps on retry).
- Confirmed correct exception raising on failure.

---
*PR created automatically by Jules for task [16718983293176053154](https://jules.google.com/task/16718983293176053154) started by @Ven0m0*